### PR TITLE
Refactor styles to dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,14 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+  min-height: 100vh;
+  background-color: #343541;
+  color: #ececf1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
 }
 
 .card {
   padding: 2em;
 }
 
-.read-the-docs {
-  color: #888;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light;
-  color: #111;
-  background-color: #f5f5f5;
+  color-scheme: dark;
+  color: #ececf1;
+  background-color: #343541;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,21 +15,22 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #19c37d;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #15a06f;
 }
 
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
-  color: #111;
-  background-color: #f5f5f5;
+  color: #ececf1;
+  background-color: #343541;
+  padding-top: 2rem;
 }
 
 h1 {
@@ -38,31 +39,39 @@ h1 {
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid #000;
+  border-radius: 4px;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #000;
+  background-color: #19c37d;
   color: #fff;
   cursor: pointer;
-  transition: opacity 0.25s;
+  transition: background-color 0.25s;
 }
 button:hover {
-  opacity: 0.8;
+  background-color: #15a06f;
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid #19c37d;
+}
+
+input,
+textarea {
+  background-color: #40414f;
+  color: #ececf1;
+  border: 1px solid #565869;
+  border-radius: 4px;
 }
 
 
 .card {
-  background-color: #ffffff;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: #444654;
+  border: 1px solid #565869;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   padding: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- refactor `App.css` with simpler root layout using a dark background
- overhaul `index.css` styles for a ChatGPT-like dark theme

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a49c6f8788324aba73ff3d714e064